### PR TITLE
BUG:  Add warning windows for landmarks set as input but not connecte…

### DIFF
--- a/PythonLibrairies/ShapeQuantifierCore.py
+++ b/PythonLibrairies/ShapeQuantifierCore.py
@@ -49,12 +49,13 @@ class ShapeQuantifierCore():
         for i in range(0,end):
             fidList = list.GetItemAsObject(i)
             landmarkDescription = self.decodeJSON(fidList.GetAttribute("landmarkDescription"))
-            for key in landmarkDescription.iterkeys():
-                markupsIndex = fidList.GetMarkupIndexByID(key)
-                if key != selectedFidReflID:
-                    fidList.SetNthMarkupLocked(markupsIndex, True)
-                else:
-                    fidList.SetNthMarkupLocked(markupsIndex, False)
+            if landmarkDescription:
+                for key in landmarkDescription.iterkeys():
+                    markupsIndex = fidList.GetMarkupIndexByID(key)
+                    if key != selectedFidReflID:
+                        fidList.SetNthMarkupLocked(markupsIndex, True)
+                    else:
+                        fidList.SetNthMarkupLocked(markupsIndex, False)
         displayNode = self.selectedModel.GetModelDisplayNode()
         displayNode.SetScalarVisibility(False)
         if selectedFidReflID != False:

--- a/Q3DC/Q3DC.py
+++ b/Q3DC/Q3DC.py
@@ -453,6 +453,20 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         fidList.SetNthFiducialPositionFromArray(numOfMarkups - 1, coord)
 
     def onComputeDistanceClicked(self):
+        fidList = self.logic.selectedFidList
+        fidListA = self.fidListComboBoxA.currentNode()
+        fidListB = self.fidListComboBoxB.currentNode()
+        nameList = [fidListA.GetName(), fidListB.GetName()]
+        if not fidList:
+            self.ShapeQuantifierCore.warningMessage("Please connect a fiducial list to a model.")
+            return
+        for fidListIter in list(set(nameList)):
+            landmarkDescription = slicer.mrmlScene.GetNodesByName(fidListIter).GetItemAsObject(0). \
+                GetAttribute("landmarkDescription")
+            if not landmarkDescription:
+                self.ShapeQuantifierCore.warningMessage(fidListIter + ' is not connected to a model. Please use "Add and Move '
+                                                        'Landmarks" panel to connect the landmarks to a model.')
+                return
         if self.computedDistanceList:
             self.exportDistanceButton.disconnect('clicked()', self.onExportButton)
             self.layout.removeWidget(self.distanceTable)
@@ -470,6 +484,22 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.logic.exportationFunction(self.directoryExportDistance, self.computedDistanceList, 'distance')
 
     def onComputeAnglesClicked(self):
+        fidList = self.ShapeQuantifierCore.selectedFidList
+        fidListline1LA = self.fidListComboBoxline1LA.currentNode()
+        fidListline1LB = self.fidListComboBoxline1LB.currentNode()
+        fidListline2LA = self.fidListComboBoxline2LA.currentNode()
+        fidListline2LB = self.fidListComboBoxline2LB.currentNode()
+        nameList = [fidListline1LA.GetName(), fidListline1LB.GetName(), fidListline2LA.GetName(), fidListline2LB.GetName()]
+        if not fidList:
+            self.ShapeQuantifierCore.warningMessage("Please connect a fiducial list to a model.")
+            return
+        for fidListIter in list(set(nameList)):
+            landmarkDescription = slicer.mrmlScene.GetNodesByName(fidListIter).GetItemAsObject(0). \
+                GetAttribute("landmarkDescription")
+            if not landmarkDescription:
+                self.ShapeQuantifierCore.warningMessage(fidListIter + ' is not connected to a model. Please use "Add and Move '
+                                                        'Landmarks" panel to connect the landmarks to a model.')
+                return
         if self.computedAnglesList:
             self.exportAngleButton.disconnect('clicked()', self.onExportAngleButton)
             self.layout.removeWidget(self.anglesTable)
@@ -496,6 +526,21 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.logic.exportationFunction(self.directoryExportAngle, self.computedAnglesList, 'angle')
 
     def onComputeLinePointClicked(self):
+        fidList = self.logic.selectedFidList
+        if not fidList:
+            self.ShapeQuantifierCore.warningMessage("Please connect a fiducial list to a model.")
+            return
+        fidListlineLA = self.fidListComboBoxlineLA.currentNode()
+        fidListlineLB = self.fidListComboBoxlineLB.currentNode()
+        fidListPoint = self.fidListComboBoxlinePoint.currentNode()
+        nameList = [fidListlineLA.GetName(), fidListlineLB.GetName(), fidListPoint.GetName()]
+        for fidListIter in list(set(nameList)):
+            landmarkDescription = slicer.mrmlScene.GetNodesByName(fidListIter).GetItemAsObject(0). \
+                GetAttribute("landmarkDescription")
+            if not landmarkDescription:
+                self.ShapeQuantifierCore.warningMessage(fidListIter + ' is not connected to a model. Please use "Add and Move '
+                                                        'Landmarks" panel to connect the landmarks to a model.')
+                return
         if self.computedLinePointList:
             self.exportLinePointButton.disconnect('clicked()', self.onExportLinePointButton)
             self.layout.removeWidget(self.linePointTable)


### PR DESCRIPTION
…d to a model (Q3DC).

This happens when using landmarks list loaded in a different session than the one they were created.

This was causing wrong measurements.

cf. [Q3DC](https://github.com/ClementMirabel/Q3DCExtension/commit/4b234e87a13035fa8924944ff2fe00b2dfde2a42)